### PR TITLE
Make CMASampler faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,18 @@ See [benchmark](./benchmark) for details.
 
 ### Execution Speed
 
-| trials/params | pycma's sampler | this library |
-| ------------- | --------------- | ------------ |
-|     100 / 10  |          6.000s |       2.386s |
-|     500 / 50  |      4m 52.008s |   2m 33.287s |
-|   1000 / 100  |     37m 41.617s |  19m 54.699s |
+| trials/params | pycma's sampler | this library | this library *1 |
+| ------------- | --------------- | ------------ | ---------------- |
+|     100 / 10  |          6.000s |       1.315s |           0.677s |
+|     500 / 50  |      4m 52.008s |   1m 33.092s |           1.750s |
+|   1000 / 100  |     37m 41.617s |  13m 35.447s |           5.563s |
+
+In the setting of "this library *1", I run a benchmark with `ensure_constant_search_space=True`.
+You can use this option when all trials suggests the same search space.
 
 [This script](./benchmark/speed_problem.py) was run on my laptop so the times should not be taken precisely.
-This library seems to be about 2-times faster than Optuna's pycma sampler (with Optuna v1.0.0 and pycma v2.7.0).
+And the times will be changed when running benchmark scripts with RDB storage.
+Even though, it is clear that this library is faster than Optuna's pycma sampler (with Optuna v1.0.0 and pycma v2.7.0).
 
 Links
 -----

--- a/benchmark/solver_cmaes.py
+++ b/benchmark/solver_cmaes.py
@@ -24,7 +24,9 @@ elif args.loglevel == "error":
 
 
 def create_study(seed):
-    sampler = CMASampler(seed=seed, n_startup_trials=args.startup)
+    sampler = CMASampler(
+        seed=seed, n_startup_trials=args.startup, ensure_constant_search_space=True,
+    )
     return optuna.create_study(sampler=sampler)
 
 

--- a/benchmark/speed_problem.py
+++ b/benchmark/speed_problem.py
@@ -25,7 +25,7 @@ def main():
     if args.sampler == "pycma":
         sampler = CmaEsSampler()
     else:
-        sampler = CMASampler()
+        sampler = CMASampler(ensure_constant_search_space=False)
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=args.trials, gc_after_trial=False)
 

--- a/examples/optuna_sampler.py
+++ b/examples/optuna_sampler.py
@@ -10,7 +10,7 @@ def objective(trial: optuna.Trial):
 
 
 def main():
-    sampler = CMASampler()
+    sampler = CMASampler(ensure_constant_search_space=True)
     study = optuna.create_study(sampler=sampler)
     study.optimize(objective, n_trials=250, gc_after_trial=False)
 


### PR DESCRIPTION
## `ensure_constant_search_space=True`

```
(venv) $ time python benchmark/speed_problem.py --sampler cmaes --trials 100 --params 10

real    0m0.620s
user    0m2.135s
sys     0m0.334s
(venv) $ time python benchmark/speed_problem.py --sampler cmaes --trials 500 --params 50

real    0m1.761s
user    0m8.176s
sys     0m1.089s
(venv) $ time python benchmark/speed_problem.py --sampler cmaes --trials 1000 --params 100

real    0m5.872s
user    0m28.797s
sys     0m4.256s
```

## `ensure_constant_search_space=False`

```
(venv) $ time python benchmark/speed_problem.py --sampler cmaes --trials 100 --params 10

real    0m1.315s
user    0m3.882s
sys     0m0.493s
(venv) $ time python benchmark/speed_problem.py --sampler cmaes --trials 500 --params 50

real    1m33.092s
user    1m50.734s
sys     0m3.636s
(venv) $ time python benchmark/speed_problem.py --sampler cmaes --trials 1000 --params 100

real    13m35.447s
user    21m40.822s
sys     1m33.418s
```