### PR TITLE
Avoid overflow of covariance matrix

### DIFF
--- a/benchmark/profile.py
+++ b/benchmark/profile.py
@@ -41,7 +41,7 @@ def main():
     profiler.dump_stats("profile.stats")
 
     stats = pstats.Stats("profile.stats")
-    stats.sort_stats('time').print_stats(5)
+    stats.sort_stats("time").print_stats(5)
 
 
 if __name__ == "__main__":

--- a/cmaes/cma.py
+++ b/cmaes/cma.py
@@ -238,6 +238,7 @@ class CMA:
             + self._c1 * rank_one
             + self._cmu * rank_mu
         )
+        self._C += 1e-16
 
 
 def _compress_symmetric(sym2d: np.ndarray) -> np.ndarray:

--- a/cmaes/cma.py
+++ b/cmaes/cma.py
@@ -238,6 +238,7 @@ class CMA:
             + self._c1 * rank_one
             + self._cmu * rank_mu
         )
+        # Avoid eigendecomposition error by arithmetic overflow
         self._C += 1e-16
 
 


### PR DESCRIPTION


```python
import argparse
import logging
import optuna

from optuna.integration.cma import CmaEsSampler
from cmaes.sampler import CMASampler

parser = argparse.ArgumentParser()
parser.add_argument("--params", type=int, default=100)
args = parser.parse_args()


def objective(trial: optuna.Trial):
    val = 0
    for i in range(args.params):
        xi = trial.suggest_uniform(str(i), -4, 4)
        val += (xi - 2) ** 2
    return val


def main():
    logging.disable(level=logging.INFO)
    sampler = CMASampler()
    study = optuna.create_study(sampler=sampler)

    study.optimize(objective, timeout=60, gc_after_trial=False)
    print(study.best_trial)


if __name__ == "__main__":
    main()
```